### PR TITLE
Proxy device classes and multiple device support

### DIFF
--- a/70-uinput-evdev-proxy.rules
+++ b/70-uinput-evdev-proxy.rules
@@ -2,4 +2,4 @@
 KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="input", MODE="660"
 
 # Create rules for your virtual devices to get persistent names
-KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="EvdevProxyDev", SYMLINK+="input/by-id/virtual-event-$attr{name}"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="EvdevProxy*", SYMLINK+="input/by-id/virtual-event-$attr{name}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "config"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,8 +195,9 @@ dependencies = [
 
 [[package]]
 name = "evdev-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "clap",
  "config",
  "crossbeam",
  "input-linux",
@@ -174,6 +207,21 @@ dependencies = [
  "serde 1.0.117",
  "serde_derive",
  "udev",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -192,6 +240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -349,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +426,30 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -487,6 +575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -535,10 +638,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evdev-proxy"
-version = "0.1.0"
-authors = ["rr"]
+version = "0.1.1"
+authors = ["redrampage"]
 edition = "2018"
 
 #[profile.release]
@@ -11,6 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "3.0.0-beta.2"
 udev = "0.5.0"
 input-linux = "0.3.0"
 nix = "0.19.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Evdev Proxy
------------
+# Evdev Proxy
 
 Proxy multiple evdev input devices to single virtual uinput device.
 
@@ -11,3 +10,114 @@ machine and only way to attach it back is to restart the guest.
 Note:
 
 This is early version, WIP.
+
+## Installation
+
+## Configuration
+
+Configuration is pretty straightforward, please refer to example `config.toml`.
+
+### How to use with QEmu
+
+Assuming you use example devices from `config.toml`, just add following args 
+to your qemu command line:
+
+    -device virtio-keyboard-pci,id=input2,bus=pci.10,addr=0x0 \
+    -device virtio-mouse-pci,id=input3,bus=pci.11,addr=0x0 \
+    -object input-linux,id=aio,evdev=/dev/input/by-id/virtual-event-EvdevProxyAIO,grab_all=on,repeat=on
+
+Or this if you want to use separate keyboard and mouse devices:
+
+    -device virtio-keyboard-pci,id=input2,bus=pci.10,addr=0x0 \
+    -device virtio-mouse-pci,id=input3,bus=pci.11,addr=0x0 \
+    -object input-linux,id=kbd,evdev=/dev/input/by-id/virtual-event-EvdevProxyKeyboard,grab_all=on,repeat=on \
+    -object input-linux,id=mouse,evdev=/dev/input/by-id/virtual-event-EvdevProxyMouse
+
+If you use `libvirt` you can do the same with following domain XML:
+
+    <domain xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0" type="kvm">
+      ...
+      <input type="keyboard" bus="virtio">
+        <address type="pci" domain="0x0000" bus="0x0a" slot="0x00" function="0x0"/>
+      </input>
+      <input type="mouse" bus="virtio">
+        <address type="pci" domain="0x0000" bus="0x0b" slot="0x00" function="0x0"/>
+      </input>
+      ...
+      <qemu:commandline>
+        <qemu:arg value="-object"/>
+        <qemu:arg value="input-linux,id=aio,evdev=/dev/input/by-id/virtual-event-EvdevProxyAIO,grab_all=yes,repeat=yes"/>
+      </qemu:commandline>
+    </domain>
+
+Of this in case of separate devices:
+
+    <domain xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0" type="kvm">
+      ...
+      <input type="keyboard" bus="virtio">
+        <address type="pci" domain="0x0000" bus="0x0a" slot="0x00" function="0x0"/>
+      </input>
+      <input type="mouse" bus="virtio">
+        <address type="pci" domain="0x0000" bus="0x0b" slot="0x00" function="0x0"/>
+      </input>
+      ...
+      <qemu:commandline>
+        <qemu:arg value="-object"/>
+        <qemu:arg value="input-linux,id=kbd,evdev=/dev/input/by-id/virtual-event-EvdevProxyKeyboard,grab_all=yes,repeat=yes"/>
+        <qemu:arg value="-object"/>
+        <qemu:arg value="input-linux,id=mouse,evdev=/dev/input/by-id/virtual-event-EvdevProxyMouse"/>
+      </qemu:commandline>
+    </domain>
+
+**NOTE**: Do not forget to add proper `xmlns:qemu` attribute to domain's root `<domain>` tag (see examples above).
+
+On starting of qemu domain it should grab specified evdev devices. To switch between host and guest press both 
+`Right Ctrl` and `Left Ctrl` keys (this is default qemu behavior).
+You can change default grab combination by adding `grab-toggle` parameter to `input-linux` object definition.
+
+Currently supported values are:
+  * ctrl-ctrl
+  * alt-alt
+  * meta-meta
+  * scrolllock
+  * ctrl-scrolllock
+
+For example:
+
+    -object input-linux,id=aio,evdev=/dev/input/by-id/virtual-event-EvdevProxyAIO,grab_all=on,repeat=on,grab-toggle=alt-alt
+
+For more information see following links:
+  * https://github.com/qemu/qemu/commit/2657846fb2e47e8ba847b5ef6fe742466414c745
+  * https://github.com/qemu/qemu/blob/master/ui/input-linux.c
+
+## Troubleshooting
+### Domain refuses to start
+If for some reason domain refuses to start, complaining about missing evdev device, try following:
+ * Ensure that /dev/uinput is accessible to the evdev-proxy.
+ * Make sure that evdev-proxy is started, and check its logs for any errors regarding device creation.
+ * If numerical evdev device (e.g `/dev/input/eventN`) is created, but no symlink is created for it in `/dev/input/by-id/`
+   make sure that you your virtual device name has `EvdevProxy` prefix in its name or create/edit corresponding udev rule
+   in `70-uinput-evdev-proxy.rules` file, or create your own.
+
+### Domain starts, but no keyboard/mouse in guest
+If domains starts fine, but no events passed to guest domain try following:
+ * Double-check that valid `input-linux` objects are passed to qemu command line (`ps aux | grep qemu`)
+ * Check evdev-proxy logs for messages about source device captures (e.g `Added new source dev "/dev/input/eventN"`),
+   also double-check selector parameters if `config.toml`.
+   
+### Mouse/Keyboard goes crazy in guest
+If you experience weird behaviour when trying to move the mouse and pressing keyboard keys simultaneously like 
+spurious mouse movements and key presses try following:
+ * Make sure that you added `virtio-input` input devices to domain configuration (see above)
+ * Make sure that guest OS use those `virtio-input` devices instead of PS/2 emulation. 
+   
+ * On linux you can check which devices xinput use, first get xinput IDs for those devices:
+   
+       xinput | grep -i virtio
+
+   Then test that xinput events are coming from them:
+
+       xinput test-xi2
+
+ * On Windows make sure that `virtio-input` drivers are installed and devices are started properly in Device Manager.
+   For latest/stable signed virtio drivers check [fedora linux site](https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/#virtio-win-direct-downloads).

--- a/config.toml
+++ b/config.toml
@@ -1,13 +1,59 @@
 log_level = "INFO"
 
-[[proxy_devices]]
-  name = "EvdevProxyDev"
-  vendor = 0x1337
-  model = 0x1337
-
-[[grab_devices]]
-  name = "none"
-# Put some selectors here to select which devices get grabbed
-#  [[grab_devices.selectors]]
-#    USBID={vendor=0x046d, model=0xc52b}
-
+##### Devices #####
+# !!! IMPORTANT NOTE !!!
+# Virtual device name should start with 'EvdevProxy' prefix, otherwise default
+# udev rules from '70-uinput-evdev-proxy.rules' won't create device symlink in
+# '/dev/input/by-id/' directory. If you want to use another name make sure to
+# configure udev accordingly.
+#
+# Available device types:
+#  * Simple -- Single virtual device that capture and proxy all devices that 
+#              match any of it's selectors
+#    Parameters:
+#      * vendor (int)     -- 16-bit device vendor ID
+#      * model (int)      -- 16-bit model vendor ID
+#      * class (enum)     -- device class (Mouse/Keyboard/AIO), 
+#                            AIO - all-in-one, device that acts both as KB 
+#                            and Mouse
+#      * selector (array) -- list of selectors that specify criteria used to 
+#                            select witch real evdev devices this virtual 
+#                            device should proxy
+#
+#    Available device selectors:
+#      * USBID      -- Simple selector that blindly selects usb device based 
+#                      on it's usb vendor:model identificator
+#      * USBIDClass -- Simple selector that blindly selects usb device based
+#                      on it's usb vendor:model identificator and device 
+#                      class (Mouse/Keyboard), useful for wireless devices
+#                      with single receiver (e.g. Logitech Unifying Receiver)
+#
+# Example devices:
+#[[device]]
+#  [device.Simple]
+#    name = "EvdevProxyKeyboard"
+#    vendor = 0x1337
+#    model = 0x1337
+#    class = "Keyboard"
+#    [[device.Simple.selector]]
+#      USBIDClass = {vendor=0x046d, model=0xc52b, class="Keyboard"}
+#
+#[[device]]
+#  [device.Simple]
+#    name = "EvdevProxyMouse"
+#    vendor = 0x1337
+#    model = 0x1338
+#    class = "Mouse"
+#    [[device.Simple.selector]]
+#      USBIDClass = {vendor=0x046d, model=0xc52b, class="Mouse"}
+#
+#[[device]]
+#  [device.Simple]
+#    name = "EvdevProxyAIO"
+#    vendor = 0x1337
+#    model = 0x1339
+#    class = "AIO"
+#    [[device.Simple.selector]]
+#      USBIDClass = {vendor=0x046d, model=0xc52b, class="Keyboard"}
+#    [[device.Simple.selector]]
+#      USBIDClass = {vendor=0x046d, model=0xc52b, class="Mouse"}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+evdev-proxy (0.1.1-1) unstable; urgency=medium
+
+  * Proxy device classes and multiple device support
+  * Added command-line parameters.
+  * Added support for multiple devices.
+  * Added support for various proxy device classes, like 'SimpleDevice'
+    creates one uinput device and forward event from all matched devices 
+
+ -- RedRampage <RedRampage@unknown>  Sun, 06 Dec 2020 22:57:48 +0300
+
 evdev-proxy (0.1.0-1) unstable; urgency=medium
 
   * Initial release

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,24 +3,25 @@ use std::path::Path;
 use config::{Config, ConfigError, File};
 use serde::export::fmt::Debug;
 
+use super::udevdetect::USBHIDClass;
+use super::proxydev::SimpleDeviceClass;
+
 #[derive(Debug, Deserialize)]
 pub struct SelfConfig {
-    pub proxy_devices: Vec<ProxyDevice>,
-    pub grab_devices: Vec<InputDevice>,
+    pub device: Vec<Device>,
+    // pub grab_devices: Vec<InputDevice>,
     pub log_level: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ProxyDevice {
-    pub name: String,
-    pub vendor: u16,
-    pub model: u16,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct InputDevice {
-    pub name: String,
-    pub selectors: Option<Vec<DeviceSelector>>,
+pub enum Device {
+    Simple {
+        name: String,
+        vendor: u16,
+        model: u16,
+        class: SimpleDeviceClass,
+        selector: Option<Vec<DeviceSelector>>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -28,6 +29,11 @@ pub enum DeviceSelector {
     USBID{
         vendor: u16,
         model: u16
+    },
+    USBIDClass{
+        vendor: u16,
+        model: u16,
+        class: USBHIDClass,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,42 @@
+#[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 extern crate pretty_env_logger;
 #[macro_use] extern crate serde_derive;
 
-use crate::udevdetect::DevIDFilter;
 use std::env;
+use std::thread;
+
+use clap::Arg;
 
 mod udevdetect;
 mod proxydev;
 mod config;
 
-// FIXME: get config path from arguments
-static CONFIG_PATH: &str = "/etc/evdev-proxy/config.toml";
+static DEFAULT_CONFIG_PATH: &str = "/etc/evdev-proxy/config.toml";
+
+fn selector_by_config(s: &config::DeviceSelector) -> Box<dyn udevdetect::DevFilter+Send+Sync> {
+    match s {
+        config::DeviceSelector::USBID{vendor, model} => {
+            Box::new(udevdetect::USBIDFilter::new(*vendor, *model))
+        },
+        config::DeviceSelector::USBIDClass{vendor, model, class} => {
+            Box::new(udevdetect::USBIDClassFilter::new(*vendor, *model, *class))
+        }
+    }
+}
 
 fn main() {
-    let conf = config::read_config(CONFIG_PATH)
+    let app = clap::App::new("evdev-proxy")
+        .about("Creates virtual devices to proxy other evdev devices with hotplug support")
+        .version(crate_version!())
+        .arg(Arg::new("config")
+            .short('c')
+            .long("config")
+            .about("Path to config file")
+            .takes_value(true)).get_matches();
+
+    let config_path = app.value_of("config").unwrap_or(DEFAULT_CONFIG_PATH);
+    let conf = config::read_config(config_path)
         .expect("Failed to read config file");
 
     match env::var("RUST_LOG") {
@@ -24,57 +47,54 @@ fn main() {
         Ok(_) => (),
     }
     pretty_env_logger::init();
-    debug!("Parsed config: {:#?}", conf);
+    info!("Parsed config: {:#?}", conf);
 
-    // FIXME!!!
-    if conf.proxy_devices.len() > 1 {
-        panic!("Only one proxy device currently supported");
-    } else if conf.proxy_devices.len() == 0 {
-        panic!("No proxy devices specified");
-    }
+    let mut threads = Vec::new();
+    for dev in conf.device {
+        match dev {
+            config::Device::Simple{name, vendor, model, class, selector} => {
+                let t = thread::spawn(move || {
+                    // create simple proxy device
+                    let pd = proxydev::Simple::new(name.as_str(), class, vendor, model, )
+                        .expect("Failed to create proxy device");
+                    info!("Proxy device initialized as '{:?}'", pd.dev_path());
 
-    // FIXME!!!
-    if conf.grab_devices.len() > 1 {
-        panic!("Only one grab device currently supported");
-    } else if conf.proxy_devices.len() == 0 {
-        panic!("No grab devices specified");
-    }
+                    // create udev listener with device selectors
+                    info!("Initializing udev listener for '{:?}'", name);
+                    let mut dl = udevdetect::DevListener::new("input", 32);
+                    for s in selector.as_ref().unwrap_or(&Vec::new()) {
+                        let filter = selector_by_config(s);
+                        dl.add_filter(filter);
+                    }
+                    let dev_ev_listener = dl.listen()
+                        .expect("Failed to listen to udev events");
 
-    let pdconf = conf.proxy_devices.first()
-        .expect("Failed to get proxy device config");
-    let pd = proxydev::ProxyDev::new(pdconf.name.as_str(), pdconf.vendor, pdconf.model)
-        .expect("Failed to create proxy device");
-    info!("Proxy devices initialized");
+                    info!("Listening for udev events for '{:?}'", name);
+                    for event in dev_ev_listener.iter() {
+                        info!("Device event for {:?}: {:?}", name, event);
+                        if event.action == udevdetect::DevEventType::Add {
+                            info!("Got matching device event for '{:?}': {:?}:{:?} ({:?})",
+                                  name, event.vendor, event.product, event.input_class);
 
-    info!("Initializing udev listener");
-    let gdconf = conf.grab_devices.first()
-        .expect("Failed to get grab device config");
-    let mut dl = udevdetect::DevListener::new("input", 32);
-    for selector in gdconf.selectors.as_ref().unwrap_or(&Vec::new()) {
-        match selector {
-            config::DeviceSelector::USBID{vendor, model} => {
-                dl.add_filter(Box::new(DevIDFilter::new(*vendor, *model)))
+                            match pd.add_source_dev(&event.devname) {
+                                Err(e) => {
+                                    error!("Failed to add matched device '{:?}': {:?}", event.devname, e);
+                                },
+                                Ok(_) => {},
+                            };
+                        }
+                        info!("Number of devices: {:}", pd.num_sources());
+                    }
+                    info!("Thread for device '{:?}' has finished", name);
+                });
+                threads.push(t);
             }
         }
     }
-    let iter = dl.listen()
-        .expect("Failed to listen to udev events");
 
-    info!("Listening for udev events");
-    for event in iter.iter() {
-        info!("GOT EVENT {:?}", event);
-
-        if event.action == udevdetect::DevEventType::Add {
-            match pd.add_source_dev(&event.devname) {
-                Err(e) => {
-                    error!("Failed to add matched device '{:?}': {:?}", event.devname, e);
-                    continue
-                },
-                Ok(_) => {},
-            };
-        }
-        info!("Number of devices: {:}", pd.num_sources());
+    // Wait for all threads
+    for t in threads {
+        t.join().unwrap();
     }
-    info!("Main thread finished");
 }
 

--- a/src/proxydev/mod.rs
+++ b/src/proxydev/mod.rs
@@ -1,6 +1,7 @@
-pub use proxy::ProxyDev;
+pub use device_simple::Simple;
+pub use device_simple::SimpleDeviceClass;
 
 mod uinput;
-mod proxy;
+mod device_simple;
 mod evdev;
 

--- a/src/udevdetect/filter_usbid.rs
+++ b/src/udevdetect/filter_usbid.rs
@@ -3,21 +3,21 @@ use udev::{Device, Event};
 use crate::udevdetect::{DevFilter, get_device_property, get_event_property};
 
 #[derive(Debug)]
-pub struct DevIDFilter {
+pub struct USBIDFilter {
     vendor: String,
     model: String,
 }
-impl DevIDFilter {
+impl USBIDFilter {
     pub fn new(vendor: u16, model: u16) -> Self {
-        let f = DevIDFilter{
+        let f = USBIDFilter {
             vendor: format!("{:04x}", vendor),
             model: format!("{:04x}", model),
         };
-        debug!("New DEVID Filter for: {:?}:{:?}", f.vendor, f.model);
+        debug!("New USBID Filter for: {:?}:{:?}", f.vendor, f.model);
         f
     }
 }
-impl DevFilter for DevIDFilter {
+impl DevFilter for USBIDFilter {
     fn match_event(&self, e: &Event) -> bool {
         if get_event_property(e, "ID_VENDOR_ID") != self.vendor {
             return false

--- a/src/udevdetect/filter_usbidclass.rs
+++ b/src/udevdetect/filter_usbidclass.rs
@@ -1,0 +1,62 @@
+use udev::{Device, Event};
+
+use crate::udevdetect::{DevFilter, get_device_property, get_event_property};
+
+// FIXME: move to common area?
+#[derive(Debug, Deserialize, Copy, Clone)]
+pub enum USBHIDClass {
+    Keyboard,
+    Mouse,
+}
+
+#[derive(Debug)]
+pub struct USBIDClassFilter {
+    vendor: String,
+    model: String,
+    class: USBHIDClass,
+}
+impl USBIDClassFilter {
+    pub fn new(vendor: u16, model: u16, class: USBHIDClass) -> Self {
+        let f = USBIDClassFilter {
+            vendor: format!("{:04x}", vendor),
+            model: format!("{:04x}", model),
+            class,
+        };
+        debug!("New USBIDClass Filter for: {:?} {:?}:{:?}", f.class, f.vendor, f.model);
+        f
+    }
+}
+impl DevFilter for USBIDClassFilter {
+    fn match_event(&self, e: &Event) -> bool {
+        if get_event_property(e, "ID_VENDOR_ID") != self.vendor {
+            return false
+        }
+        if get_event_property(e, "ID_MODEL_ID") != self.model {
+            return false
+        }
+        if get_event_property(e, get_class_prop(&self.class)) != "1" {
+            return false
+        }
+        true
+    }
+
+    fn match_device(&self, e: &Device) -> bool {
+        if get_device_property(e, "ID_VENDOR_ID") != self.vendor {
+            return false
+        }
+        if get_device_property(e, "ID_MODEL_ID") != self.model {
+            return false
+        }
+        if get_device_property(e, get_class_prop(&self.class)) != "1" {
+            return false
+        }
+        true
+    }
+}
+
+fn get_class_prop(c: &USBHIDClass) -> &str {
+    match c {
+        USBHIDClass::Keyboard => "ID_INPUT_KEYBOARD",
+        USBHIDClass::Mouse => "ID_INPUT_MOUSE",
+    }
+}

--- a/src/udevdetect/mod.rs
+++ b/src/udevdetect/mod.rs
@@ -6,11 +6,14 @@ pub use self::listener::DevEvent;
 pub use self::listener::DevEventType;
 pub use self::listener::DevListener;
 pub use self::filter::DevFilter;
-pub use self::filter_dev_id::DevIDFilter;
+pub use self::filter_usbid::USBIDFilter;
+pub use self::filter_usbidclass::USBIDClassFilter;
+pub use self::filter_usbidclass::USBHIDClass;
 
 mod listener;
 mod filter;
-mod filter_dev_id;
+mod filter_usbid;
+mod filter_usbidclass;
 
 fn get_event_property<'a>(ev: &'a Event, key: &'a str) -> &'a str {
     ev.property_value(key).unwrap_or(OsStr::new("")).to_str().unwrap_or("")


### PR DESCRIPTION
- Added command-line parameters.
- Added support for multiple devices.
- Added support for various proxy device classes, like:
   * Simple device (implemented) -- creates one uinput device and forward event from all matched devices
   * Group device (planned) -- create multiple uinput device groups and switch matched devices between them on some key combination
- More verbose readme and example config