### PR TITLE
Support all possible keys instead of only a subset

### DIFF
--- a/src/proxydev/uinput.rs
+++ b/src/proxydev/uinput.rs
@@ -4,138 +4,6 @@ use std::io;
 use input_linux::{EventKind, InputId, Key, MiscKind, RelativeAxis, UInputHandle};
 use input_linux::sys;
 
-static KEYBOARD_KEYS: [Key; 106] = [
-    // Row 1
-    Key::Esc,
-
-    Key::F1,
-    Key::F2,
-    Key::F3,
-    Key::F4,
-    Key::F5,
-    Key::F6,
-    Key::F7,
-    Key::F8,
-    Key::F9,
-    Key::F10,
-    Key::F11,
-    Key::F12,
-
-    Key::Print,
-    Key::Sysrq,
-    Key::ScrollLock,
-    Key::Pause,
-    Key::Break,
-
-    // Row 2
-    Key::Grave,
-    Key::Num1,
-    Key::Num2,
-    Key::Num3,
-    Key::Num4,
-    Key::Num5,
-    Key::Num6,
-    Key::Num7,
-    Key::Num8,
-    Key::Num9,
-    Key::Num0,
-    Key::Minus,
-    Key::Equal,
-    Key::Backspace,
-
-    Key::Insert,
-    Key::Home,
-    Key::PageUp,
-
-    Key::NumLock,
-    Key::KpSlash,
-    Key::KpAsterisk,
-    Key::KpMinus,
-
-    // Row 3
-    Key::Tab,
-    Key::Q,
-    Key::W,
-    Key::E,
-    Key::R,
-    Key::T,
-    Key::Y,
-    Key::U,
-    Key::I,
-    Key::O,
-    Key::P,
-    Key::LeftBrace,
-    Key::RightBrace,
-    Key::Backslash,
-
-    Key::Delete,
-    Key::End,
-    Key::PageDown,
-
-    Key::Kp7,
-    Key::Kp8,
-    Key::Kp9,
-    Key::KpPlus,
-
-    // Row 4
-    Key::CapsLock,
-    Key::A,
-    Key::S,
-    Key::D,
-    Key::F,
-    Key::G,
-    Key::H,
-    Key::J,
-    Key::K,
-    Key::L,
-    Key::Semicolon,
-    Key::Apostrophe,
-    Key::Enter,
-
-    Key::Kp4,
-    Key::Kp5,
-    Key::Kp6,
-
-    // Row 5
-    Key::LeftShift,
-    Key::Z,
-    Key::X,
-    Key::C,
-    Key::V,
-    Key::B,
-    Key::N,
-    Key::M,
-    Key::Comma,
-    Key::Dot,
-    Key::Slash,
-    Key::RightShift,
-
-    Key::Up,
-
-    Key::Kp1,
-    Key::Kp2,
-    Key::Kp3,
-    Key::KpEnter,
-
-    // Row 6
-    Key::LeftCtrl,
-    Key::LeftMeta,
-    Key::LeftAlt,
-    Key::Space,
-    Key::RightAlt,
-    Key::Fn,
-    Key::Menu,
-    Key::RightCtrl,
-
-    Key::Left,
-    Key::Down,
-    Key::Right,
-
-    Key::Kp0,
-    Key::KpDot,
-
-];
-
 static MOUSE_KEYS: [Key; 18] = [
     // Mouse buttons
     Key::Button0,
@@ -181,9 +49,9 @@ pub fn new_uinput_kbd(name: &str, vendor: u16, product: u16) -> io::Result<UInpu
         handle.set_mscbit(*m)?;
     }
 
-    for k in &KEYBOARD_KEYS {
+    for k in Key::iter() {
         debug!("Setting KeyBit flag: {:?}", k);
-        handle.set_keybit(*k)?;
+        handle.set_keybit(k)?;
     }
 
     handle.create(&id, name.as_bytes(), 0, &vec![])?;
@@ -253,9 +121,9 @@ pub fn new_uinput_aio(name: &str, vendor: u16, product: u16) -> io::Result<UInpu
         handle.set_mscbit(*m)?;
     }
 
-    for k in &KEYBOARD_KEYS {
+    for k in Key::iter() {
         debug!("Setting KeyBit flag: {:?}", k);
-        handle.set_keybit(*k)?;
+        handle.set_keybit(k)?;
     }
     for k in &MOUSE_KEYS {
         debug!("Setting Mouse KeyBit flag: {:?}", k);


### PR DESCRIPTION
Pretend the virtual device supports all possible keys that are known to input_linux. The previous array was missing some widely used keys such as Key::RightMeta, but also keys commonly mapped such as Key::Compose.

I have used this patch for months now with a Windows 10 virtual machine and I have not yet noticed any disadvantages or problems.